### PR TITLE
Инкремент 4

### DIFF
--- a/cmd/agent/cmdline.go
+++ b/cmd/agent/cmdline.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"errors"
+	"flag"
+)
+
+type arguments struct {
+	hostport       string
+	reportInterval int
+	pollInterval   int
+}
+
+func parseCmdline() (args *arguments, err error) {
+	args = &arguments{}
+	flag.StringVar(&args.hostport, "a", "localhost:8080", "")
+	flag.IntVar(&args.reportInterval, "r", 10, "")
+	flag.IntVar(&args.pollInterval, "p", 10, "")
+	flag.Parse()
+	switch {
+	case args.hostport == "":
+		err = errors.New("-a is not specified")
+	case args.reportInterval < 1 || args.reportInterval > 100:
+		err = errors.New("-p value is allowed between 1 and 99")
+	case args.pollInterval < 1 || args.pollInterval > 100:
+		err = errors.New("-p value is allowed between 1 and 99")
+	}
+	return
+}

--- a/cmd/server/cmdline.go
+++ b/cmd/server/cmdline.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"errors"
+	"flag"
+)
+
+type arguments struct {
+	hostport string
+}
+
+func parseCmdline() (args *arguments, err error) {
+	args = &arguments{}
+	flag.StringVar(&args.hostport, "a", "localhost:8080", "")
+	flag.Parse()
+	switch {
+	case args.hostport == "":
+		err = errors.New("-a is not specified")
+	}
+	return
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log"
 	"net/http"
 
 	metricsAPI "github.com/crazylazyowl/metrics-tpl/internal/controller/httprest/metrics"
@@ -9,11 +10,16 @@ import (
 )
 
 func main() {
+	args, err := parseCmdline()
+	if err != nil {
+		log.Fatalln(err)
+	}
+
 	storage := memstorage.New()
 
 	usecase := metricsUsecase.New(storage)
 
 	router := metricsAPI.NewRouter(usecase)
 
-	_ = http.ListenAndServe("localhost:8080", router)
+	_ = http.ListenAndServe(args.hostport, router)
 }


### PR DESCRIPTION
Доработайте код, чтобы он умел принимать аргументы с использованием флагов.

Аргументы сервера:
Флаг `-a=<ЗНАЧЕНИЕ>` отвечает за адрес эндпоинта HTTP-сервера (по умолчанию `localhost:8080`).

Аргументы агента:
Флаг `-a=<ЗНАЧЕНИЕ>` отвечает за адрес эндпоинта HTTP-сервера (по умолчанию `localhost:8080`).
Флаг `-r=<ЗНАЧЕНИЕ>` позволяет переопределять `reportInterval` — частоту отправки метрик на сервер (по умолчанию 10 секунд).
Флаг `-p=<ЗНАЧЕНИЕ>` позволяет переопределять `pollInterval` — частоту опроса метрик из пакета runtime (по умолчанию 2 секунды).

При попытке передать приложению незвестные флаги оно должно завершаться с сообщением о соответствующей ошибке.

Значения интервалов времени должны задаваться в секундах.

Во всех случаях должны присутствовать значения по умолчанию.